### PR TITLE
fix: wrap directory per-file loads in catch_unwind via load_dicos_path

### DIFF
--- a/crates/roxel/src/app.rs
+++ b/crates/roxel/src/app.rs
@@ -466,7 +466,7 @@ impl App {
 
         self.ui.volumes.clear();
         for file in &files {
-            match volume::load_dicos_volume(file) {
+            match volume::load_dicos_path(file) {
                 Ok(vol) => {
                     let name = file
                         .file_stem()


### PR DESCRIPTION
## Summary

- In `load_directory`, each file was loaded via `volume::load_dicos_volume(file)`, which calls the codec directly without panic protection.
- This patch changes it to `volume::load_dicos_path(file)`, routing through the same `catch_unwind` wrapper already used by `load_single_file`.
- A panicking codec during directory batch-load no longer crashes the viewer; the offending file is skipped with a warning.

## Test plan

- [x] `cargo build -p roxel` compiles cleanly with no warnings
- [x] `cargo test` — all 327 tests pass across all crates

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)