### PR TITLE
fix: validate generator --size x/y dimensions fit in u16

### DIFF
--- a/crates/dicos/src/bin/dicos-gen-luggage-fishtank.rs
+++ b/crates/dicos/src/bin/dicos-gen-luggage-fishtank.rs
@@ -137,6 +137,14 @@ fn parse_size(s: &str) -> Result<[usize; 3], String> {
             "--size values must be >= 32 in each axis for this generator",
         ));
     }
+    if out[0] > u16::MAX as usize || out[1] > u16::MAX as usize {
+        return Err(format!(
+            "--size x and y must be at most {} (DICOM ROWS/COLUMNS u16 limit); got x={}, y={}",
+            u16::MAX,
+            out[0],
+            out[1],
+        ));
+    }
     Ok(out)
 }
 


### PR DESCRIPTION
## Summary

- In `parse_size`, after the existing `>= 32` lower-bound check, validate that the X and Y dimensions do not exceed `u16::MAX` before they are cast with `as u16` when writing the DICOM `ROWS` and `COLUMNS` tags.
- Z/frames is intentionally excluded from the upper-bound check because DICOM does not encode frame count as a `u16`.
- A `--size` value >65535 for X or Y now returns a clear error instead of silently wrapping.

Closes #9

## Test plan

- [x] `cargo build -p dicos` compiles without warnings
- [x] `cargo test -p dicos` — all 86 tests pass
- [ ] Manual: `dicos-gen-luggage-fishtank --size 70000,512,10` should now print a descriptive error and exit non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)