### PR TITLE
fix: normalize native uncompressed pixel data to PixelData::Native in reader

### DIFF
--- a/crates/dicos/src/reader.rs
+++ b/crates/dicos/src/reader.rs
@@ -154,6 +154,7 @@ impl<R: Read> DicosReader<R> {
             ds.insert(elem);
         }
 
+        normalize_native_pixel_data(&mut ds);
         Ok(ds)
     }
 
@@ -712,6 +713,58 @@ fn parse_sequence_items(
     Ok(items)
 }
 
+/// Normalizes raw OW/OB pixel data bytes to PixelData::Native after parsing.
+///
+/// The reader stores fixed-length (7FE0,0010) as Value::Bytes. This converts
+/// them to PixelData::Native so Dataset::pixel_data() works for all datasets.
+fn normalize_native_pixel_data(ds: &mut Dataset) {
+    let rows = ds.rows() as usize;
+    let cols = ds.columns() as usize;
+    let num_frames = ds.number_of_frames() as usize;
+
+    if rows == 0 || cols == 0 {
+        return;
+    }
+
+    let frame_pixels = rows * cols;
+
+    // Check if pixel data is raw bytes (uncompressed, fixed-length)
+    let should_normalize = matches!(
+        ds.get(tag::PIXEL_DATA).map(|e| &e.value),
+        Some(Value::Bytes(_))
+    );
+
+    if !should_normalize {
+        return;
+    }
+
+    let raw_bytes = match ds.remove(tag::PIXEL_DATA) {
+        Some(elem) => match elem.value {
+            Value::Bytes(b) => b,
+            _ => return,
+        },
+        None => return,
+    };
+
+    // Decode as little-endian u16 pixels
+    let all_pixels: Vec<u16> = raw_bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+
+    let frames: Vec<Vec<u16>> = if num_frames > 1 && all_pixels.len() == frame_pixels * num_frames {
+        all_pixels.chunks(frame_pixels).map(|c| c.to_vec()).collect()
+    } else {
+        vec![all_pixels]
+    };
+
+    ds.insert(Element::new(
+        tag::PIXEL_DATA,
+        Vr::OW,
+        Value::PixelData(PixelData::Native { frames }),
+    ));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1070,12 +1123,11 @@ mod tests {
         assert_eq!(ds.rows(), 2);
         assert_eq!(ds.columns(), 2);
 
-        // Pixel data comes back as raw bytes (OW)
-        let pd_elem = ds.get(tag::PIXEL_DATA).expect("should have pixel data");
-        match &pd_elem.value {
-            Value::Bytes(b) => assert_eq!(b.len(), 8), // 4 pixels x 2 bytes
-            other => panic!("expected Bytes, got {other:?}"),
-        }
+        // Raw OW bytes are normalized to PixelData::Native after parsing
+        let pd = ds.pixel_data().expect("pixel_data() should return Some");
+        let frames = pd.native_frames().expect("should be native pixel data");
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0], vec![100u16, 200, 300, 400]);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/dicos/src/writer.rs
+++ b/crates/dicos/src/writer.rs
@@ -473,16 +473,11 @@ mod tests {
 
         assert_eq!(rt.rows(), 2);
         assert_eq!(rt.columns(), 2);
-        let pd_elem = rt.get(tag::PIXEL_DATA).expect("should have pixel data");
-        match &pd_elem.value {
-            Value::Bytes(b) => {
-                assert_eq!(b.len(), 8);
-                // Verify first pixel
-                let p0 = u16::from_le_bytes([b[0], b[1]]);
-                assert_eq!(p0, 100);
-            }
-            other => panic!("expected Bytes, got {other:?}"),
-        }
+        // After roundtrip the reader normalizes raw OW bytes to PixelData::Native
+        let pd = rt.pixel_data().expect("pixel_data() should return Some");
+        let frames = pd.native_frames().expect("should be native pixel data");
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0], vec![100u16, 200, 300, 400]);
     }
 
     #[test]

--- a/crates/dicos/tests/synthetic_luggage_example.rs
+++ b/crates/dicos/tests/synthetic_luggage_example.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use dicos::reader;
 use dicos::tag;
-use dicos::types::Value;
+use dicos::types::{PixelData, Value};
 
 fn sample_path() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -59,17 +59,17 @@ fn bag_ct_sample_has_non_uniform_pixel_data() {
     let cols = ds.columns() as usize;
     let frames = ds.number_of_frames() as usize;
 
-    let pixel = ds.get(tag::PIXEL_DATA).expect("pixel data present");
-    let raw = match &pixel.value {
-        Value::Bytes(b) => b,
-        other => panic!("expected native pixel bytes, got {other:?}"),
+    // After normalization, pixel data is PixelData::Native, not raw bytes.
+    let pd = ds.pixel_data().expect("pixel_data() should return Some");
+    let native_frames = match pd {
+        PixelData::Native { frames: ref f } => f,
+        other => panic!("expected native pixel data, got {other:?}"),
     };
 
-    assert_eq!(raw.len(), rows * cols * frames * 2);
-    let voxels: Vec<u16> = raw
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .collect();
+    let total_pixels: usize = native_frames.iter().map(|f| f.len()).sum();
+    assert_eq!(total_pixels, rows * cols * frames);
+
+    let voxels: Vec<u16> = native_frames.iter().flat_map(|f| f.iter().copied()).collect();
 
     let min = voxels.iter().copied().min().expect("non-empty pixels");
     let max = voxels.iter().copied().max().expect("non-empty pixels");


### PR DESCRIPTION
## Summary

- Adds `normalize_native_pixel_data()` post-processing step at the end of `read_dataset` in `crates/dicos/src/reader.rs`
- Converts fixed-length `(7FE0,0010)` OW/OB elements stored as `Value::Bytes` into `Value::PixelData(PixelData::Native { frames })`, using rows/columns/number_of_frames from the dataset metadata
- `Dataset::pixel_data()` now works correctly for all uncompressed datasets without callers needing to match `Value::Bytes` as a fallback

## Test plan

- [ ] `parse_with_native_pixel_data` in `reader.rs` updated to assert `PixelData::Native` with correct pixel values
- [ ] `roundtrip_native_pixel_data` in `writer.rs` updated to assert `PixelData::Native` after roundtrip
- [ ] `bag_ct_sample_has_non_uniform_pixel_data` integration test updated to use `Dataset::pixel_data()` and `PixelData::Native`
- [ ] `cargo test` passes: 331 tests, 0 failures

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)